### PR TITLE
Use Hackage compatible stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
 flags: {}
 extra-package-dbs: []
+pvp-bounds: both
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
I've already seen clit-0.1.0.0 fail to build on one of our  Hackage CI systems, so there's a very high chance the Hackage doc-builder will fail to builds the docs as well. By using this setting Stack will automatically provide enough meta-data when you upload to Hackage so that the doc-builder should be able to build this package's docs succesful.

Moreover, the `description` ("Please see README.md") is not really a proper description for your package (and Hackage will show a link to the README at the end of/below the description *if* the README exists; therefore that phrase is redundant), and hence this will cause a sub-optimal experience for users (NB: your package won't be properly indexed by Hackage's package search feature and thus hurt its discoverability). See also [this posting](https://mail.haskell.org/pipermail/haskell-cafe/2016-November/125541.html) for more details.

PS: As expected, here's the failure: http://hackage.haskell.org/package/clit-0.1.0.0/reports/

PS2: in addition to this PR you should also modify the lower bound on `base` to say `base >= 4.8` as currently the build would fail with pre-AMP Preludes due to e.g. `<$>` not being exported